### PR TITLE
Add unit declarator to class and module declarations

### DIFF
--- a/src/Perl5/World.pm
+++ b/src/Perl5/World.pm
@@ -1,5 +1,5 @@
 
-class Perl5::World;
+unit class Perl5::World;
 
 
 

--- a/src/Perl5/bytes.pm
+++ b/src/Perl5/bytes.pm
@@ -7,4 +7,4 @@ sub EXPORT(|) {
     { '$*USE_BYTES' => +($*SCOPE eq 'use'); }
 }
 
-module bytes;
+unit module bytes;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.