### PR TITLE
Add `use nqp` to files directly using nqp routines

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,4 +1,5 @@
 use v6;
+use nqp;
 use Panda::Common;
 use Panda::Builder;
 use Panda::Tester;

--- a/src/Perl5.pm
+++ b/src/Perl5.pm
@@ -1,4 +1,3 @@
-
 use Perl5::Grammar;
 use Perl5::ModuleLoader;
 

--- a/src/Perl5/Actions.pm
+++ b/src/Perl5/Actions.pm
@@ -1,3 +1,4 @@
+use nqp;
 use NQPP6QRegex:from<NQP>;
 use NQPP5QRegex:from<NQP>;
 use Perl5::World;

--- a/src/Perl5/Cwd.pm
+++ b/src/Perl5/Cwd.pm
@@ -1,5 +1,5 @@
-
 use v6.0.0;
+use nqp;
 
 module Cwd {
     our sub cwd             { nqp::p6box_s(nqp::cwd()) }

--- a/src/Perl5/Grammar.pm
+++ b/src/Perl5/Grammar.pm
@@ -1,3 +1,4 @@
+use nqp;
 use Perl5::Actions;
 use QRegex:from<NQP>;
 use Perl5::World;

--- a/src/Perl5/ModuleLoader.pm
+++ b/src/Perl5/ModuleLoader.pm
@@ -1,3 +1,5 @@
+use nqp;
+
 my $V5MLDEBUG = %*ENV<V5MLDEBUG>;
 my $p6ml      = nqp::gethllsym('perl6', 'ModuleLoader');
 

--- a/src/Perl5/Terms.pm
+++ b/src/Perl5/Terms.pm
@@ -1,5 +1,5 @@
-
 use v6.0.0;
+use nqp;
 
 my %SIG;
 my %INC;

--- a/src/Perl5/constant.pm
+++ b/src/Perl5/constant.pm
@@ -1,5 +1,5 @@
-
 use v6.0.0;
+use nqp;
 
 # http://perldoc.perl.org/constant.html
 sub EXPORT(*@ops) {

--- a/src/Perl5/overload.pm
+++ b/src/Perl5/overload.pm
@@ -1,5 +1,5 @@
-
 use v6.0.0;
+use nqp;
 
 # http://perldoc.perl.org/overload.html
 my $fallback;


### PR DESCRIPTION
Using nqp routines is now restricted to Rakudo core unless one specifies the
`use nqp` pragma.  The old usage is deprecated and will be removed
completely in the 2015.09 release of Rakudo.  This change brings the files
which use nqp routines up to date with current Rakudo.